### PR TITLE
Fix `scaladoc` sbt project build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p sbt/target laikaIO/.jvm/target scaladoc/.jvm/target core/.js/target jsinterop/.js/target core/.jvm/target project/target
+        run: mkdir -p sbt/target laikaIO/.jvm/target core/.js/target jsinterop/.js/target core/.jvm/target scaladoc/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar sbt/target laikaIO/.jvm/target scaladoc/.jvm/target core/.js/target jsinterop/.js/target core/.jvm/target project/target
+        run: tar cf targets.tar sbt/target laikaIO/.jvm/target core/.js/target jsinterop/.js/target core/.jvm/target scaladoc/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -55,10 +55,9 @@ lazy val root =
       core,
       laikaIO,
       jsInterop,
-      scaladoc,
     )
     .configureRoot { root =>
-      root.aggregate(plugin) // don't include the plugin in rootJVM, only in root
+      root.aggregate(plugin, scaladoc) // don't include the plugin in rootJVM, only in root
     }
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -107,10 +107,9 @@ lazy val laikaIO = crossProject(JVMPlatform)
     },
   )
 
-lazy val scaladoc = crossProject(JVMPlatform)
-  .crossType(CrossType.Pure)
+lazy val scaladoc = project
   .in(file("scaladoc"))
-  .dependsOn(core)
+  .dependsOn(core.jvm)
   .settings(
     name := "protosearch-scaladoc",
     crossScalaVersions := Seq(Scala212),


### PR DESCRIPTION
This PR sets the `scaladoc` sbt project to be a JVM and Scala 2.12 project, just like the `plugin` project.
This should fix our CI failures.