### PR TITLE
Add `ProtosearchScaladocPlugin`, modify search.html to support other indexes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val jsInterop = crossProject(JSPlatform)
 lazy val plugin =
   project
     .in(file("sbt"))
-    .dependsOn(core.jvm, laikaIO.jvm, scaladoc.jvm)
+    .dependsOn(core.jvm, laikaIO.jvm, scaladoc)
     .enablePlugins(SbtPlugin)
     .settings(
       name := "protosearch-sbt",

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val jsInterop = crossProject(JSPlatform)
 lazy val plugin =
   project
     .in(file("sbt"))
-    .dependsOn(core.jvm, laikaIO.jvm)
+    .dependsOn(core.jvm, laikaIO.jvm, scaladoc.jvm)
     .enablePlugins(SbtPlugin)
     .settings(
       name := "protosearch-sbt",

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
@@ -1,4 +1,4 @@
-function render(hit) {
+function renderDoc(hit) {
   const path = hit.fields.path
   const link = "../" + hit.fields.path.replace(".txt", ".html")
   const title = hit.fields.title
@@ -25,18 +25,41 @@ function render(hit) {
 `
   )
 }
+function renderScaladoc(hit) {
+  const title = hit.fields.functionName
+  const description = hit.fields.description
+  return (
+`
+<ol>
+  <div class="card">
+    <div class="card-content">
+      <div class="level-left">
+        <p class="title is-capitalized is-flex-wrap-wrap">
+          <span>${title}</span>
+        </p>
+      </div>
+      <p class="subtitle">${description}</p>
+    </div>
+  </div>
+</ol>
+`
+  )
+}
 
 async function main() {
   var app = document.getElementById("app")
   var searchBar = document.getElementById("search_input")
   const urlParams = new URLSearchParams(location.search)
+
+  const renderFunction = urlParams.get("type") == "scaladoc" ? renderScaladoc : renderDoc
+
   const maybeIndex = urlParams.get("index")
   const workerJS = maybeIndex ? `worker.js?index=${maybeIndex}` : "worker.js"
 
   const worker = new Worker(workerJS)
   worker.onmessage = function(e) {
     console.log(e.data)
-    const markup = e.data.map(render).join("\n")
+    const markup = e.data.map(renderFunction).join("\n")
     app.innerHTML = markup
   }
 

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/search.js
@@ -1,10 +1,43 @@
+function render(hit) {
+  const path = hit.fields.path
+  const link = "../" + hit.fields.path.replace(".txt", ".html")
+  const title = hit.fields.title
+  const preview = hit.fields.body.slice(0, 150) + "..."
+  return (
+`
+<ol>
+  <div class="card">
+    <div class="card-content">
+      <p class="is-size-6 has-text-grey-light">
+        <span>${path}</span>
+      </p>
+      <div class="level-left">
+        <p class="title is-capitalized is-flex-wrap-wrap">
+          <a href="${link}" target="_blank">
+            <span>${title}</span>
+          </a>
+        </p>
+      </div>
+      <p class="subtitle">${preview}</p>
+    </div>
+  </div>
+</ol>
+`
+  )
+}
+
 async function main() {
   var app = document.getElementById("app")
   var searchBar = document.getElementById("search_input")
+  const urlParams = new URLSearchParams(location.search)
+  const maybeIndex = urlParams.get("index")
+  const workerJS = maybeIndex ? `worker.js?index=${maybeIndex}` : "worker.js"
 
-  const worker = new Worker("worker.js")
+  const worker = new Worker(workerJS)
   worker.onmessage = function(e) {
-    app.innerHTML = e.data
+    console.log(e.data)
+    const markup = e.data.map(render).join("\n")
+    app.innerHTML = markup
   }
 
   searchBar.addEventListener('input', function () {

--- a/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
+++ b/laikaIO/src/main/resources/pink/cozydev/protosearch/sbt/worker.js
@@ -1,47 +1,21 @@
 importScripts("./protosearch.js")
 
-async function getQuerier() {
-  let querier = fetch("./searchIndex.idx")
+async function getQuerier(index) {
+  let querier = fetch("./" + index + ".idx")
     .then(res => res.blob())
     .then(blob => QuerierBuilder.load(blob))
     .catch((error) => console.error("getQuerier error: ", error));
   return await querier
 }
-const querierPromise = getQuerier()
+const urlParams = new URLSearchParams(location.search)
+const maybeIndex = urlParams.get("index")
+const index = maybeIndex ? maybeIndex : "searchIndex"
 
-function render(hit) {
-  const path = hit.fields.path
-  const link = "../" + hit.fields.path.replace(".txt", ".html")
-  const title = hit.fields.title
-  const preview = hit.fields.body.slice(0, 150) + "..."
-  return (
-`
-<ol>
-  <div class="card">
-    <div class="card-content">
-      <p class="is-size-6 has-text-grey-light">
-        <span>${path}</span>
-      </p>
-      <div class="level-left">
-        <p class="title is-capitalized is-flex-wrap-wrap">
-          <a href="${link}" target="_blank">
-            <span>${title}</span>
-          </a>
-        </p>
-      </div>
-      <p class="subtitle">${preview}</p>
-    </div>
-  </div>
-</ol>
-`
-  )
-}
+const querierPromise = getQuerier(index)
 
 async function searchIt(query) {
   const querier = await querierPromise
   return querier.search(query)
-    .map(render)
-    .join("\n")
 }
 
 onmessage = async function(e) {

--- a/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchScaladocPlugin.scala
+++ b/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchScaladocPlugin.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.protosearch.sbt
+
+import sbt.*
+import sbt.Keys.*
+import sbt.nio.file.FileTreeView
+import java.nio.file.Path
+
+object ProtosearchScaladocPlugin extends AutoPlugin {
+
+  lazy val myScalaSourceFiles: TaskKey[Seq[File]] =
+    taskKey[Seq[File]]("List all Scala files")
+
+  private def findScalaSourceFiles: Def.Initialize[Task[Seq[File]]] = Def.task {
+    val sourceGlobs = (Compile / sourceDirectories).value.map(f => f.toGlob / "**" / "*.scala")
+    val scalaSourceFiles: Seq[Path] = sourceGlobs
+      .map(g =>
+        FileTreeView.default.list(g).collect {
+          case (path, attributes) if attributes.isRegularFile => path
+        }
+      )
+      .flatten
+    println(s"sourceFiles: ${scalaSourceFiles}")
+    scalaSourceFiles.map(_.toFile())
+  }
+  override val trigger = allRequirements
+
+  override def requires = plugins.JvmPlugin
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    myScalaSourceFiles := findScalaSourceFiles.value
+  )
+}

--- a/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchScaladocPlugin.scala
+++ b/sbt/src/main/scala/pink/cozydev/protosearch/ProtosearchScaladocPlugin.scala
@@ -47,8 +47,8 @@ object ProtosearchScaladocPlugin extends AutoPlugin {
       .emits(scalaSourceFiles)
       .flatMap { path =>
         val p = Path.fromNioPath(path)
-        val content = Files[IO].readAll(p).through(fs2.text.utf8.decode)
-        content.map(ParseScaladoc.parseAndExtractInfo)
+        val getContent = Files[IO].readAll(p).through(fs2.text.utf8.decode).compile.string
+        Stream.eval(getContent).map(ParseScaladoc.parseAndExtractInfo)
       }
       .flatMap(Stream.emits)
 


### PR DESCRIPTION
This PR adds a new sbt plugin, `ProtosearchScaladocPlugin`, which creates indexes using `ScaladocIndexer`.
Additionally we add support for two different query parameters to `search.html`

### `index=`
The `index` query parameter lets us specify the index name to look for in the `/search` directory

### `type=scaladoc`
This changes the result rendering function to `renderScaladoc` which uses the scaladoc fields


This is a temporary design that lets us get off the ground and start customizing and testing the scaladoc search experience.